### PR TITLE
Empty and delete the bucket before attempting to run Terraform destroy

### DIFF
--- a/.github/workflows/ephemeral-environment-for-pull-request.yaml
+++ b/.github/workflows/ephemeral-environment-for-pull-request.yaml
@@ -180,6 +180,16 @@ jobs:
           terraform init -backend-config="bucket=${{ secrets.TF_STATE_BUCKET }}"
           terraform workspace select pr-${{ github.event.number }}
 
+      - name: Empty and delete the bucket
+        env:
+          # Common configuration
+          R2_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: |
+          source env/bin/activate
+          invoke bucket_delete
+
       - name: Destroy PR environment
         working-directory: infra/terraform/cloudflare_environment
         env:

--- a/tasks.py
+++ b/tasks.py
@@ -205,7 +205,7 @@ def bucket_delete(c):
         extra_args_base = {}
     else:
         # Using AWS S3
-        print(f"Deleting AWS S3 bucket {BUCKET_NAME}"
+        print(f"Deleting AWS S3 bucket {BUCKET_NAME}")
         s3 = boto3.client("s3")
 
     bucket = s3.Bucket(BUCKET_NAME)

--- a/tasks.py
+++ b/tasks.py
@@ -184,7 +184,30 @@ def bucket_delete(c):
         print("Aborting at user request.")
         exit(1)
 
-    s3 = boto3.resource("s3")
+    # Get bucket name from environment variable or use default
+    BUCKET_NAME = os.environ.get("BUCKET_NAME", "www.ec2instances.info")
+
+    # Determine if we're using R2 or S3 based on environment variables
+    if os.environ.get("R2_ACCOUNT_ID"):
+        # Using R2
+        print(f"Deleting Cloudflare R2 bucket {BUCKET_NAME}")
+        endpoint_url = (
+            f"https://{os.environ.get('R2_ACCOUNT_ID')}.r2.cloudflarestorage.com"
+        )
+        s3 = boto3.client(
+            "s3",
+            endpoint_url=endpoint_url,
+            aws_access_key_id=os.environ.get("R2_ACCESS_KEY_ID"),
+            aws_secret_access_key=os.environ.get("R2_SECRET_ACCESS_KEY"),
+            region_name="auto",
+        )
+        # R2 doesn't support ACL
+        extra_args_base = {}
+    else:
+        # Using AWS S3
+        print(f"Deleting AWS S3 bucket {BUCKET_NAME}"
+        s3 = boto3.client("s3")
+
     bucket = s3.Bucket(BUCKET_NAME)
 
     # Delete all objects in the bucket first


### PR DESCRIPTION
- Extended the existing bucket deletion task to also handle Cloudflare R2 besides AWS S3.
- invoke this task in the teardown-environment Github action that runs when pull requests are merged.