### PR TITLE
Make the teardown run only after the environment was created 

### DIFF
--- a/.github/workflows/ephemeral-environment-for-pull-request.yaml
+++ b/.github/workflows/ephemeral-environment-for-pull-request.yaml
@@ -149,6 +149,7 @@ jobs:
             })
 
   teardown-environment:
+    needs: [setup-environment]
     runs-on: ubuntu-latest
     if: github.event.action == 'closed'
 


### PR DESCRIPTION
This is needed to resolve a race condition in the Terraform workspace handling. 

Otherwise the jobs run in parallel for pull requests closed quickly and the teardown fails to find the terraform workspace because it wasn't yet created in the setup-environment step.